### PR TITLE
Codecov badge fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/smd)](https://CRAN.R-project.org/package=smd)
 [![R-CMD-check](https://github.com/bsaul/smd/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/bsaul/smd/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/bsaul/smd/branch/main/graph/badge.svg)](https://app.codecov.io/gh/bsaul/smd?branch=main)
+[![Codecov test coverage](https://codecov.io/gh/bsaul/smd/branch/master/graph/badge.svg)](https://app.codecov.io/gh/bsaul/smd?branch=master)
 <!-- badges: end -->
 
 An `R` package for computing the standardized mean difference between two groups for various data types. 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@
 
 An `R` package for computing the standardized mean difference between two groups for various data types. 
 
-```r
+``` r
+library(smd)
+
 x <- rnorm(100)
 g <- rep(1:2, each = 50)
-smd(x, g)
+
+smd(x, g, std.error = TRUE)
+#>   term  estimate std.error
+#> 1    2 0.1653336 0.2003414
 ```
 
 See [using smd](https://bsaul.github.io/smd/articles/smd_usage.html) for more details.


### PR DESCRIPTION
It looks like the badge was pointing to the main branch instead of the master! ⭐ 

I also updated the example in the README to show the result. Hope that is ok by you.

<img width="1049" alt="image" src="https://github.com/bsaul/smd/assets/26774684/ea951812-1b63-4e6d-857d-16f2a3dc5b8a">
