### PR TITLE
Adjusting n_mean_var to handle factor with empty levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,9 @@ Authors@R: c(person("Bradley", "Saul", role = c("aut", "cre"),
              person("Matt", "Phelan", role = c("ctb"), 
                     email = "mpphelan1@gmail.com"),
              person("Daniel", "Sjoberg", role = c("ctb"),
-                    email = "danield.sjoberg@gmail.com")
+                    email = "danield.sjoberg@gmail.com"),
+             person("Nuvan", "Rathnayaka", role = c("ctb"),
+                    email = "nuvanrath@mail.proton.me")
              )
 Description: Computes standardized mean differences and confidence intervals for 
     multiple data types based on Yang, D., & Dalton, J. E. (2012) 

--- a/R/mean_var.R
+++ b/R/mean_var.R
@@ -142,6 +142,7 @@ setMethod(
 
     n <- sum(w)
     p <- tapply(w, x, function(r) if(n == 0) 0 else sum(r)/n)
+    p[is.na(p)] <- 0 #for empty level in factor, converts proportion from NA to 0.
     list(n = n, mean = p, var = multinom_var(p))
   })
 

--- a/R/mean_var.R
+++ b/R/mean_var.R
@@ -141,8 +141,7 @@ setMethod(
     }
 
     n <- sum(w)
-    p <- tapply(w, x, function(r) if(n == 0) 0 else sum(r)/n)
-    p[is.na(p)] <- 0 #for empty level in factor, converts proportion from NA to 0.
+    p <- tapply(w, x, function(r) if(n == 0) 0 else sum(r)/n, default = 0)
     list(n = n, mean = p, var = multinom_var(p))
   })
 

--- a/tests/testthat/test_mean_var.R
+++ b/tests/testthat/test_mean_var.R
@@ -95,3 +95,49 @@ test_that("n_mean_var runs with NA values", {
     "list")
 })
 
+## all observations have the same value of X, smd should be 0
+
+test_that("unweighted n_mean_var with character x produces prop of 1", {
+  x <- c("Male", "Male", "Male")
+  res <- n_mean_var(x)
+  expect_equal(res$mean[[1]], 1)
+})
+
+test_that("weighted n_mean_var with character x produces prop of 1", {
+  x <- c("Male", "Male", "Male")
+  w <- c(1, 1, 1)
+  res <- n_mean_var(x, w)
+  expect_equal(res$mean[[1]], 1)
+})
+
+test_that("unweighted n_mean_var with one-level x produces prop of 1", {
+  x <- c("Male", "Male", "Male")
+  x <- factor(x)
+  res <- n_mean_var(x)
+  expect_equal(res$mean[[1]], 1)
+})
+
+test_that("weighted n_mean_var with one-level x produces prop of 1", {
+  x <- c("Male", "Male", "Male")
+  x <- factor(x)
+  w <- c(1, 1, 1)
+  res <- n_mean_var(x, w)
+  expect_equal(res$mean[[1]], 1)
+})
+
+test_that("unweighted n_mean_var with two-level x produces smd of 0", {
+  x <- c("Male", "Male", "Male")
+  x <- factor(x, levels = c("Female", "Male"))
+  res <- n_mean_var(x)
+  expect_equal(res$mean[[1]], 0)
+  expect_equal(res$mean[[2]], 1)
+})
+
+test_that("weighted n_mean_var with two-level x produces smd of 0", {
+  x <- c("Male", "Male", "Male")
+  x <- factor(x, levels = c("Female", "Male"))
+  w <- c(1, 1, 1)
+  res <- n_mean_var(x, w)
+  expect_equal(res$mean[[1]], 0)
+  expect_equal(res$mean[[2]], 1)
+})

--- a/tests/testthat/test_smd.R
+++ b/tests/testthat/test_smd.R
@@ -297,12 +297,6 @@ test_that("smd() with two-level factor and one treatment group has an empty leve
   #.    = sqrt(2)
   expect_equal(smd(x, g)$estimate, sqrt(2))
   expect_equal(smd(x, g, w)$estimate, sqrt(2))
-  
-  x <- c(rep("No", 8), rep("Yes", 4), rep("No", 4))
-  g <- c(rep("Control", 8), rep("Treat", 8))
-  w <- rep(1, 16)
-  expect_equal(smd(x, g)$estimate, sqrt(2))
-  expect_equal(smd(x, g, w)$estimate, sqrt(2))
 })
 
 test_that("smd() with two-level character vector and one treatment group has an empty level", {

--- a/tests/testthat/test_smd.R
+++ b/tests/testthat/test_smd.R
@@ -309,20 +309,6 @@ test_that("smd() with two-level character vector and one treatment group has an 
   x <- c(rep("No", 8), rep("Yes", 4), rep("No", 4))
   g <- c(rep("Control", 8), rep("Treat", 8))
   w <- rep(1, 16)
-  # Hand calculation of SMD
-  # Control mean =  a = [1 0]'
-  # Control var = c = diag(a) - outer(a,a) = [1 0; 0 0] - [1 0; 0 0] = [0 0; 0 0]
-  # Treat mean = b = [0.5 0.5]'
-  # Control var = d = diag(b) - outer(b,b) = [0.5 0; 0 0.5] - [0.25 0.25; 0.25 0.25] = [0.25 -0.25; -0.25 0.25]
-  # D = a - b = [0.5  -0.5]'
-  # S = (c + d)/2 = [0.125 -0.125; -0.125 0.125]
-  # S^-1 = [2 -2; -2 2]
-  # SMD = sqrt(D' S^-1 D)
-  #.    = sqrt([0.5 -0.5]*[2  -2]*[0.5] 
-  #                       [-2  2] [-0.5])
-  #.    = sqrt([2 -2][ 0.5]
-  #                  [-0.5])
-  #.    = sqrt(2)
   expect_equal(smd(x, g)$estimate, sqrt(2))
   expect_equal(smd(x, g, w)$estimate, sqrt(2))
 })

--- a/tests/testthat/test_smd.R
+++ b/tests/testthat/test_smd.R
@@ -249,3 +249,51 @@ test_that("smd(x, g, w) works when x is character or logical", {
     smd(x_fct, g, w)
   )
 })
+
+x <- factor(rep("No", 10))
+g <- factor(rep(c("Control", "Treat"), 5))
+w <- rep(c(3.12, 1.47), 5)
+expect_equal(smd(x, g)$estimate, 0)
+expect_equal(smd(x, g, w)$estimate, 0)
+})
+
+
+test_that("smd() when character has one level returns 0", {
+  x <- rep("No", 10)
+  g <- factor(rep(c("Control", "Treat"), 5))
+  w <- rep(c(3.12, 1.47), 5)
+  expect_equal(smd(x, g)$estimate, 0)
+  expect_equal(smd(x, g, w)$estimate, 0)
+})
+
+
+test_that("smd() when two-level factor has one empty level returns 0", {
+  x <- factor(rep("No", 10), levels = c("No", "Yes"))
+  g <- factor(rep(c("Control", "Treat"), 5))
+  w <- rep(c(3.12, 1.47), 5)
+  expect_equal(smd(x, g)$estimate, 0)
+  expect_equal(smd(x, g, w)$estimate, 0)
+})
+
+
+test_that("smd() with two-level factor and one treatment group has an empty level", {
+  x <- factor(c(rep("No", 8), rep("Yes", 4), rep("No", 4)), levels = c("No", "Yes"))
+  g <- factor(c(rep("Control", 8), rep("Treat", 8)))
+  w <- rep(1, 16)
+  # Hand calculation of SMD
+  # Control mean =  a = [1 0]'
+  # Control var = c = diag(a) - outer(a,a) = [1 0; 0 0] - [1 0; 0 0] = [0 0; 0 0]
+  # Treat mean = b = [0.5 0.5]'
+  # Control var = d = diag(b) - outer(b,b) = [0.5 0; 0 0.5] - [0.25 0.25; 0.25 0.25] = [0.25 -0.25; -0.25 0.25]
+  # D = a - b = [0.5  -0.5]'
+  # S = (c + d)/2 = [0.125 -0.125; -0.125 0.125]
+  # S^-1 = [2 -2; -2 2]
+  # SMD = sqrt(D' S^-1 D)
+  #.    = sqrt([0.5 -0.5]*[2  -2]*[0.5] 
+  #                       [-2  2] [-0.5])
+  #.    = sqrt([2 -2][ 0.5]
+  #                  [-0.5])
+  #.    = sqrt(2)
+  expect_equal(smd(x, g)$estimate, sqrt(2))
+  expect_equal(smd(x, g, w)$estimate, sqrt(2))
+})

--- a/tests/testthat/test_smd.R
+++ b/tests/testthat/test_smd.R
@@ -250,6 +250,7 @@ test_that("smd(x, g, w) works when x is character or logical", {
   )
 })
 
+test_that("smd() when factor has one level returns 0", {
 x <- factor(rep("No", 10))
 g <- factor(rep(c("Control", "Treat"), 5))
 w <- rep(c(3.12, 1.47), 5)

--- a/tests/testthat/test_smd.R
+++ b/tests/testthat/test_smd.R
@@ -297,4 +297,32 @@ test_that("smd() with two-level factor and one treatment group has an empty leve
   #.    = sqrt(2)
   expect_equal(smd(x, g)$estimate, sqrt(2))
   expect_equal(smd(x, g, w)$estimate, sqrt(2))
+  
+  x <- c(rep("No", 8), rep("Yes", 4), rep("No", 4))
+  g <- c(rep("Control", 8), rep("Treat", 8))
+  w <- rep(1, 16)
+  expect_equal(smd(x, g)$estimate, sqrt(2))
+  expect_equal(smd(x, g, w)$estimate, sqrt(2))
+})
+
+test_that("smd() with two-level character vector and one treatment group has an empty level", {
+  x <- c(rep("No", 8), rep("Yes", 4), rep("No", 4))
+  g <- c(rep("Control", 8), rep("Treat", 8))
+  w <- rep(1, 16)
+  # Hand calculation of SMD
+  # Control mean =  a = [1 0]'
+  # Control var = c = diag(a) - outer(a,a) = [1 0; 0 0] - [1 0; 0 0] = [0 0; 0 0]
+  # Treat mean = b = [0.5 0.5]'
+  # Control var = d = diag(b) - outer(b,b) = [0.5 0; 0 0.5] - [0.25 0.25; 0.25 0.25] = [0.25 -0.25; -0.25 0.25]
+  # D = a - b = [0.5  -0.5]'
+  # S = (c + d)/2 = [0.125 -0.125; -0.125 0.125]
+  # S^-1 = [2 -2; -2 2]
+  # SMD = sqrt(D' S^-1 D)
+  #.    = sqrt([0.5 -0.5]*[2  -2]*[0.5] 
+  #                       [-2  2] [-0.5])
+  #.    = sqrt([2 -2][ 0.5]
+  #                  [-0.5])
+  #.    = sqrt(2)
+  expect_equal(smd(x, g)$estimate, sqrt(2))
+  expect_equal(smd(x, g, w)$estimate, sqrt(2))
 })


### PR DESCRIPTION
When both treatment groups have the same categorical value for x, the SMD should be 0, and this computation works as expected when x is a character vector or a factor vector with one level:

```
library(smd
#Character vector
 x <- rep("No", 10)
  g <- factor(rep(c("Control", "Treat"), 5))
  w <- rep(c(3.12, 1.47), 5)
  testthat::expect_equal(smd(x, g)$estimate, 0)
  testthat::expect_equal(smd(x, g, w)$estimate, 0)

# One-level factor
x <- factor(rep("No", 10))
g <- factor(rep(c("Control", "Treat"), 5))
w <- rep(c(3.12, 1.47), 5)
testthat::expect_equal(smd(x, g)$estimate, 0)
testthat::expect_equal(smd(x, g, w)$estimate, 0)
```

However, when x is a two-level factor with one empty level an error is produced in the weighted case:
```
 x <- factor(rep("No", 10), levels = c("No", "Yes"))
  g <- factor(rep(c("Control", "Treat"), 5))
  w <- rep(c(3.12, 1.47), 5)
  testthat::expect_equal(smd(x, g)$estimate, 0) #passes
  testthat::expect_equal(smd(x, g, w)$estimate, 0) #throws Error in svd(X) : infinite or missing values in 'x'
```

This is occurring inside the `n_mean_var` helper function called by `smd`. In the unweighted case, the method called has `signature  = c("factor", "missing")`, and relies on the base R `table()` function, which correctly handles an empty-level of a factor by giving it a count of 0.
```
#' @rdname n_mean_var
setMethod(
  f          = "n_mean_var",
  signature  = c("factor", "missing"),
  definition = function(x, w, na.rm = FALSE){

    if(na.rm == TRUE){
      x <- stats::na.omit(x)
    }

    p <- prop.table(table(x))
    list(n = length(x), mean = p, var = multinom_var(p))
})
```

Unfortunately for the weighted case, `table()` doesn't accommodate weights, so `tapply` is used to compute the counts within levels of a factor before dividing by the weighted sum to get the proportion. When given a factor with an empty-level, `tapply` fills in the value for that empty level with `NA`, which corrupts downstream calculation

```
#' @rdname n_mean_var
setMethod(
  f          = "n_mean_var",
  signature  = c("factor", "numeric"),
  definition = function(x, w, na.rm = FALSE){

    if(na.rm == TRUE){
      kp <- !is.na(x)
      w <- w[kp]
      x <- x[kp]
    }

    n <- sum(w)
    p <- tapply(w, x, function(r) if(n == 0) 0 else sum(r)/n)
    list(n = n, mean = p, var = multinom_var(p))
  })
```

The proposed fix is to reset any NAs in the p vector to 0 after the `tapply` call
```
p[is.na(p)] <- 0
```

