### PR TITLE
use unweighted variance for denominator for weighted smd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: smd
 Type: Package
 Title: Compute Standardized Mean Differences
-Version: 0.6.8
+Version: 0.7.0
 Authors@R: c(person("Bradley", "Saul", role = c("aut", "cre"), 
                     email = "bradleysaul@fastmail.com"),
              person("Alex", "Breskin", role = c("ctb"), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(person("Bradley", "Saul", role = c("aut", "cre"),
              person("Daniel", "Sjoberg", role = c("ctb"),
                     email = "danield.sjoberg@gmail.com"),
              person("Nuvan", "Rathnayaka", role = c("ctb"),
-                    email = "nuvanrath@mail.proton.me")
+                    email = "nuvanrath@proton.me")
              )
 Description: Computes standardized mean differences and confidence intervals for 
     multiple data types based on Yang, D., & Dalton, J. E. (2012) 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,6 @@ URL: https://bsaul.github.io/smd/
 BugReports: https://github.com/bsaul/smd/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 VignetteBuilder: knitr
 Repository: cran.novisci.com

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Authors@R: c(person("Bradley", "Saul", role = c("aut", "cre"),
              )
 Description: Computes standardized mean differences and confidence intervals for 
     multiple data types based on Yang, D., & Dalton, J. E. (2012) 
-    <http://www.lerner.ccf.org/qhs/software/lib/stddiff.pdf>. 
+    <https://support.sas.com/resources/papers/proceedings12/335-2012.pdf>. 
 Imports:
   MASS (>= 7.3-50),
   methods (>= 3.5.1)

--- a/R/mean_var.R
+++ b/R/mean_var.R
@@ -21,7 +21,7 @@ multinom_var <- function(p){
 #' @param x a vector of values
 #' @param w an optional vector of \code{numeric} weights
 #' @param na.rm passed to \code{sum}
-#' @param unwgt.var Defaults to \code{TRUE}
+#' @param unwgt.var Use unweighted or weighted covariance matrix
 #' @importFrom stats var
 #' @importFrom methods setGeneric setMethod
 #' @return a list containing \code{mean} and \code{var}
@@ -42,7 +42,7 @@ setMethod(
 
     n    <- length(x)
     mean <- sum(x)/n
-
+    
     list(
       n    = n,
       mean = mean,
@@ -68,14 +68,16 @@ setMethod(
 
     xw   <- x * w
     n    <- sum(w)
+
     # Handle case were sum of weights is 0
     if(n == 0){
       mean = 0
       var = 0
     } else if(unwgt.var == TRUE){
       mean = sum(xw)/n
-      unwgt_mean = sum(x)/n
-      var = sum((x - mean)^2)/n
+      unwgt_n = length(x)
+      unwgt_mean = sum(x)/unwgt_n
+      var = sum((x - unwgt_mean)^2)/unwgt_n
     } else {
       mean = sum(xw)/n
       var = sum(w*(x - mean)^2)/n
@@ -86,6 +88,17 @@ setMethod(
       mean = mean,
       var  = var
     )
+    
+    # xw   <- x * w
+    # n    <- sum(w)
+    # # Handle case were sum of weights is 0
+    # mean <- if(n == 0) 0 else sum(xw)/n
+    # 
+    # list(
+    #   n    = n,
+    #   mean = mean,
+    #   var  = if(n == 0) 0 else sum(w*(x - mean)^2)/n
+    # )
 })
 
 
@@ -150,7 +163,7 @@ setMethod(
       w <- w[kp]
       x <- x[kp]
     }
-
+    
     n <- sum(w)
     p <- tapply(w, x, function(r) if(n == 0) 0 else sum(r)/n, default = 0)
     if(unwgt.var == TRUE){
@@ -161,6 +174,10 @@ setMethod(
     }
 
     list(n = n, mean = p, var = var)
+    
+    # n <- sum(w)
+    # p <- tapply(w, x, function(r) if(n == 0) 0 else sum(r)/n, default = 0)
+    # list(n = n, mean = p, var = multinom_var(p))
   })
 
 #' @rdname n_mean_var

--- a/R/mean_var.R
+++ b/R/mean_var.R
@@ -88,17 +88,6 @@ setMethod(
       mean = mean,
       var  = var
     )
-    
-    # xw   <- x * w
-    # n    <- sum(w)
-    # # Handle case were sum of weights is 0
-    # mean <- if(n == 0) 0 else sum(xw)/n
-    # 
-    # list(
-    #   n    = n,
-    #   mean = mean,
-    #   var  = if(n == 0) 0 else sum(w*(x - mean)^2)/n
-    # )
 })
 
 
@@ -174,10 +163,6 @@ setMethod(
     }
 
     list(n = n, mean = p, var = var)
-    
-    # n <- sum(w)
-    # p <- tapply(w, x, function(r) if(n == 0) 0 else sum(r)/n, default = 0)
-    # list(n = n, mean = p, var = multinom_var(p))
   })
 
 #' @rdname n_mean_var

--- a/R/mean_var.R
+++ b/R/mean_var.R
@@ -73,7 +73,7 @@ setMethod(
     list(
       n    = n,
       mean = mean,
-      var  = if(n == 0) 0 else sum(w*(x - mean)^2)/n
+      var  = if(n == 0) 0 else sum((x - mean)^2)/n
     )
 })
 
@@ -142,7 +142,8 @@ setMethod(
 
     n <- sum(w)
     p <- tapply(w, x, function(r) if(n == 0) 0 else sum(r)/n, default = 0)
-    list(n = n, mean = p, var = multinom_var(p))
+    unwt_p <- prop.table(table(x)) #for unweighted variance
+    list(n = n, mean = p, var = multinom_var(unwt_p))
   })
 
 #' @rdname n_mean_var

--- a/R/smd.R
+++ b/R/smd.R
@@ -24,6 +24,7 @@
 #' \eqn{\bar{x}_g = \hat{p}_g}, i.e. the sample proportion and \eqn{s^2_g = \hat{p}_g(1 - \hat{p}_g)}.
 #'
 #' @name smd
+#'
 #' @param x a \code{vector} or \code{matrix} of values
 #' @param g a vector of at least 2 groups to compare. This should coercable to a
 #'    \code{factor}.
@@ -33,6 +34,7 @@
 #' @param na.rm Remove \code{NA} values from \code{x}? Defaults to \code{FALSE}.
 #' @param gref an integer indicating which level of \code{g} to use as the reference
 #'     group. Defaults to \code{1}.
+#' @param unwgt.var Defaults to \code{TRUE}
 #' @importFrom methods setGeneric setMethod
 #' @return a \code{data.frame} containing standardized mean differences between
 #'    levels of \code{g} for values of \code{x}. The \code{data.frame} contains
@@ -49,13 +51,13 @@
 #' smd(x, g)
 setGeneric(
   "smd",
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
 
     if(gref < 1 || gref > length(unique(g))){
       stop(sprintf("gref must be an integer within %s", length(unique(g))))
     }
 
-    parts <- compute_smd_parts(.x = x, .g = g, .w = w, .na = na.rm, .ref = gref)
+    parts <- compute_smd_parts(.x = x, .g = g, .w = w, .na = na.rm, .ref = gref, .unwgt = unwgt.var)
     d     <- compute_smd_pairwise(parts)
     out   <- list(term = names(d), estimate = unname(d))
 
@@ -74,8 +76,8 @@ setGeneric(
 setMethod(
   "smd",
   signature = c("character", "ANY", "missing"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
-    smd(x = as.factor(x), g = g, std.error = std.error, na.rm = na.rm, gref = gref)
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
+    smd(x = as.factor(x), g = g, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)
   }
 )
 
@@ -85,8 +87,8 @@ setMethod(
 setMethod(
   "smd",
   signature = c("character", "ANY", "numeric"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
-    smd(x = as.factor(x), g = g, w = w, std.error = std.error, na.rm = na.rm, gref = gref)
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
+    smd(x = as.factor(x), g = g, w = w, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)
   }
 )
 
@@ -96,8 +98,8 @@ setMethod(
 setMethod(
   "smd",
   signature = c("logical", "ANY", "missing"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
-    smd(x = as.numeric(x), g = g, std.error = std.error, na.rm = na.rm, gref = gref)
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
+    smd(x = as.numeric(x), g = g, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)
   }
 )
 
@@ -107,8 +109,8 @@ setMethod(
 setMethod(
   "smd",
   signature = c("logical", "ANY", "numeric"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
-    smd(x = as.numeric(x), g = g, w = w, std.error = std.error, na.rm = na.rm, gref = gref)
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
+    smd(x = as.numeric(x), g = g, w = w, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)
   }
 )
 
@@ -118,14 +120,14 @@ setMethod(
 setMethod(
   "smd",
   signature = c("matrix", "ANY",  "missing"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
 
     if(std.error){
       stop("smd is not set up to compute std.error on a matrix")
     }
 
     apply(x, 2, function(j) {
-      simplify2array(smd(x = j, g = g, std.error = std.error, na.rm = na.rm, gref = gref)$estimate)
+      simplify2array(smd(x = j, g = g, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)$estimate)
     })
   }
 )
@@ -136,7 +138,7 @@ setMethod(
 setMethod(
   "smd",
   signature = c("matrix", "ANY", "numeric"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
     if(std.error){
       stop("smd is not set up to compute std.error on a matrix")
     }
@@ -144,7 +146,8 @@ setMethod(
     apply(x, 2, function(j) {
       simplify2array(smd(x = j, w = w, g = g,
                          std.error = std.error,
-                         na.rm = na.rm, gref = gref)$estimate)
+                         na.rm = na.rm, gref = gref,
+                         unwgt.var = unwgt.var)$estimate)
     })
   }
 )
@@ -155,10 +158,10 @@ setMethod(
 setMethod(
   "smd",
   signature = c("list", "ANY", "missing"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
 
     tidy_smd_multiplevar(lapply(x, function(z) {
-      smd(x = z, g = g, std.error = std.error, na.rm = na.rm, gref = gref)
+      smd(x = z, g = g, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)
     }))
   }
 )
@@ -169,10 +172,10 @@ setMethod(
 setMethod(
   "smd",
   signature = c("list",  "ANY", "numeric"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
 
     tidy_smd_multiplevar(lapply(x, function(z) {
-      smd(x = z, g = g, w = w, std.error = std.error, na.rm = na.rm, gref = gref)
+      smd(x = z, g = g, w = w, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)
     }))
   }
 )
@@ -183,10 +186,10 @@ setMethod(
 setMethod(
   "smd",
   signature = c("data.frame", "ANY", "missing"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
 
     tidy_smd_multiplevar(lapply(x, function(z) {
-      smd(x = z, g = g, std.error = std.error, na.rm = na.rm, gref = gref)
+      smd(x = z, g = g, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)
     }))
   }
 )
@@ -197,10 +200,10 @@ setMethod(
 setMethod(
   "smd",
   signature = c("data.frame", "ANY", "numeric"),
-  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L){
+  def = function(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE){
 
     tidy_smd_multiplevar(lapply(x, function(z) {
-      smd(x = z, g = g,  w = w, std.error = std.error, na.rm = na.rm, gref = gref)
+      smd(x = z, g = g,  w = w, std.error = std.error, na.rm = na.rm, gref = gref, unwgt.var = unwgt.var)
     }))
   }
 )
@@ -288,10 +291,11 @@ compute_smd_var <- function(d, smd_parts){
 #' @param .g a vector of groupings to compare
 #' @param .na \code{TRUE/FALSE}. \code{NA} handling
 #' @param .ref integer position of the reference group
+#' @param .unwgt Use unweighted or weighted covariance.
 #' @param applyFUN the \code{FUN} used to compute the SMD parts. Defaults to
 #' \code{\link{n_mean_var}}
 #' @keywords internal
-compute_smd_parts <- function(.x, .g, .w, .na, .ref,
+compute_smd_parts <- function(.x, .g, .w, .na, .ref, .unwgt,
                               applyFUN = n_mean_var){
 
   # Checks
@@ -320,7 +324,7 @@ compute_smd_parts <- function(.x, .g, .w, .na, .ref,
   dd$w <- if(missing(.w)) NULL else .w
   ll  <- split.data.frame(dd, f = .g)
   U   <- simplify2array(lapply(ll, function(M){
-    do.call(applyFUN, args = append(M, list(na.rm = .na)))
+    do.call(applyFUN, args = append(M, list(na.rm = .na, unwgt.var = .unwgt)))
   }))
 
   # Create pairwise components

--- a/R/smd.R
+++ b/R/smd.R
@@ -23,13 +23,14 @@
 #' For a \code{logical} or \code{factor} with only two levels, the equation above is
 #' \eqn{\bar{x}_g = \hat{p}_g}, i.e. the sample proportion and \eqn{s^2_g = \hat{p}_g(1 - \hat{p}_g)}.
 #'
-#' When using the SMD to evaluate the effectiveness of weighting in achieving covariate balance,
-#' it is important to isolate the change in SMD before and after weighting to the change in mean
-#' difference, so the denominator (covariance matrix) must be held constant. By default, the 
-#' unweighted covariance matrix is used to compute SMD in both the unweighted and weighted case. 
-#' If the weights are not being used to adjust for covariate imbalance (e.g. case weights), 
-#' the \code{unwgt.var} argument can be set to \code{FALSE} to use the weighted covariance matrix 
-#' as the denominator.
+#' When using the SMD to evaluate the effectiveness of weighting in achieving 
+#' covariate balance, it is important to isolate the change in SMD before and 
+#' after weighting to the change in mean difference, so the denominator (covariance matrix) 
+#' must be held constant \href{https://doi.org/10.1002/sim.3207}{Stuart 2008}. 
+#' By default, the unweighted covariance matrix is used to compute SMD in both 
+#' the unweighted and weighted case. If the weights are not being used to adjust 
+#' for covariate imbalance (e.g. case weights), the \code{unwgt.var} argument 
+#' can be set to \code{FALSE} to use the weighted covariance matrix as the denominator.
 #'
 #' @name smd
 #'

--- a/R/smd.R
+++ b/R/smd.R
@@ -23,6 +23,14 @@
 #' For a \code{logical} or \code{factor} with only two levels, the equation above is
 #' \eqn{\bar{x}_g = \hat{p}_g}, i.e. the sample proportion and \eqn{s^2_g = \hat{p}_g(1 - \hat{p}_g)}.
 #'
+#' When using the SMD to evaluate the effectiveness of weighting in achieving covariate balance,
+#' it is important to isolate the change in SMD before and after weighting to the change in mean
+#' difference, so the denominator (covariance matrix) must be held constant. By default, the 
+#' unweighted covariance matrix is used to compute SMD in both the unweighted and weighted case. 
+#' If the weights are not being used to adjust for covariate imbalance (e.g. case weights), 
+#' the \code{unwgt.var} argument can be set to \code{FALSE} to use the weighted covariance matrix 
+#' as the denominator.
+#'
 #' @name smd
 #'
 #' @param x a \code{vector} or \code{matrix} of values
@@ -34,7 +42,7 @@
 #' @param na.rm Remove \code{NA} values from \code{x}? Defaults to \code{FALSE}.
 #' @param gref an integer indicating which level of \code{g} to use as the reference
 #'     group. Defaults to \code{1}.
-#' @param unwgt.var Defaults to \code{TRUE}
+#' @param unwgt.var Use unweighted or weighted covariance matrix. Defaults to \code{TRUE}
 #' @importFrom methods setGeneric setMethod
 #' @return a \code{data.frame} containing standardized mean differences between
 #'    levels of \code{g} for values of \code{x}. The \code{data.frame} contains

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -21,7 +21,7 @@ check_for_two_levels <- function(x){
 #' @keywords internal
 
 lapplyFUNpairwise <- function(x, f, ref){
-  if(sum(is.na(x)) >= 1) stop("x contians NA value")
+  if(sum(is.na(x)) >= 1) stop("x contains NA value")
   lapply(x[-ref], FUN = function(y) { f(x[[ref]], y) })
 }
 

--- a/man/compute_smd_parts.Rd
+++ b/man/compute_smd_parts.Rd
@@ -4,7 +4,7 @@
 \alias{compute_smd_parts}
 \title{Compute components of SMD}
 \usage{
-compute_smd_parts(.x, .g, .w, .na, .ref, applyFUN = n_mean_var)
+compute_smd_parts(.x, .g, .w, .na, .ref, .unwgt, applyFUN = n_mean_var)
 }
 \arguments{
 \item{.x}{a vector of values}
@@ -16,6 +16,8 @@ compute_smd_parts(.x, .g, .w, .na, .ref, applyFUN = n_mean_var)
 \item{.na}{\code{TRUE/FALSE}. \code{NA} handling}
 
 \item{.ref}{integer position of the reference group}
+
+\item{.unwgt}{Use unweighted or weighted covariance.}
 
 \item{applyFUN}{the \code{FUN} used to compute the SMD parts. Defaults to
 \code{\link{n_mean_var}}}

--- a/man/n_mean_var.Rd
+++ b/man/n_mean_var.Rd
@@ -14,27 +14,27 @@
 \alias{n_mean_var,character,numeric-method}
 \title{Compute n, mean and variance}
 \usage{
-n_mean_var(x, w = NULL, na.rm = FALSE)
+n_mean_var(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{numeric,missing}(x, w = NULL, na.rm = FALSE)
+\S4method{n_mean_var}{numeric,missing}(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{numeric,numeric}(x, w = NULL, na.rm = FALSE)
+\S4method{n_mean_var}{numeric,numeric}(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{integer,missing}(x, w = NULL, na.rm = FALSE)
+\S4method{n_mean_var}{integer,missing}(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{integer,numeric}(x, w = NULL, na.rm = FALSE)
+\S4method{n_mean_var}{integer,numeric}(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{logical,missing}(x, na.rm = FALSE)
+\S4method{n_mean_var}{logical,missing}(x, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{logical,numeric}(x, w = NULL, na.rm = FALSE)
+\S4method{n_mean_var}{logical,numeric}(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{factor,missing}(x, w = NULL, na.rm = FALSE)
+\S4method{n_mean_var}{factor,missing}(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{factor,numeric}(x, w = NULL, na.rm = FALSE)
+\S4method{n_mean_var}{factor,numeric}(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{character,missing}(x, w = NULL, na.rm = FALSE)
+\S4method{n_mean_var}{character,missing}(x, w = NULL, na.rm = FALSE, unwgt.var = TRUE)
 
-\S4method{n_mean_var}{character,numeric}(x, w = NULL, na.rm = TRUE)
+\S4method{n_mean_var}{character,numeric}(x, w = NULL, na.rm = TRUE, unwgt.var = TRUE)
 }
 \arguments{
 \item{x}{a vector of values}
@@ -42,6 +42,8 @@ n_mean_var(x, w = NULL, na.rm = FALSE)
 \item{w}{an optional vector of \code{numeric} weights}
 
 \item{na.rm}{passed to \code{sum}}
+
+\item{unwgt.var}{Use unweighted or weighted covariance matrix}
 }
 \value{
 a list containing \code{mean} and \code{var}

--- a/man/smd.Rd
+++ b/man/smd.Rd
@@ -14,27 +14,27 @@
 \alias{smd,data.frame,ANY,numeric-method}
 \title{Compute Standardized Mean Difference}
 \usage{
-smd(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+smd(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{character,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{character,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{character,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{character,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{logical,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{logical,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{logical,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{logical,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{matrix,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{matrix,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{matrix,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{matrix,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{list,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{list,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{list,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{list,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{data.frame,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{data.frame,ANY,missing}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 
-\S4method{smd}{data.frame,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
+\S4method{smd}{data.frame,ANY,numeric}(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 }
 \arguments{
 \item{x}{a \code{vector} or \code{matrix} of values}
@@ -51,6 +51,8 @@ smd(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L)
 
 \item{gref}{an integer indicating which level of \code{g} to use as the reference
 group. Defaults to \code{1}.}
+
+\item{unwgt.var}{Defaults to \code{TRUE}}
 }
 \value{
 a \code{data.frame} containing standardized mean differences between

--- a/man/smd.Rd
+++ b/man/smd.Rd
@@ -87,13 +87,14 @@ the sample variance.
 For a \code{logical} or \code{factor} with only two levels, the equation above is
 \eqn{\bar{x}_g = \hat{p}_g}, i.e. the sample proportion and \eqn{s^2_g = \hat{p}_g(1 - \hat{p}_g)}.
 
-When using the SMD to evaluate the effectiveness of weighting in achieving covariate balance,
-it is important to isolate the change in SMD before and after weighting to the change in mean
-difference, so the denominator (covariance matrix) must be held constant. By default, the 
-unweighted covariance matrix is used to compute SMD in both the unweighted and weighted case. 
-If the weights are not being used to adjust for covariate imbalance (e.g. case weights), 
-the \code{unwgt.var} argument can be set to \code{FALSE} to use the weighted covariance matrix 
-as the denominator.
+When using the SMD to evaluate the effectiveness of weighting in achieving 
+covariate balance, it is important to isolate the change in SMD before and 
+after weighting to the change in mean difference, so the denominator (covariance matrix) 
+must be held constant \href{https://doi.org/10.1002/sim.3207}{Stuart 2008}. 
+By default, the unweighted covariance matrix is used to compute SMD in both 
+the unweighted and weighted case. If the weights are not being used to adjust 
+for covariate imbalance (e.g. case weights), the \code{unwgt.var} argument 
+can be set to \code{FALSE} to use the weighted covariance matrix as the denominator.
 }
 \examples{
 x <- rnorm(100)

--- a/man/smd.Rd
+++ b/man/smd.Rd
@@ -52,7 +52,7 @@ smd(x, g, w, std.error = FALSE, na.rm = FALSE, gref = 1L, unwgt.var = TRUE)
 \item{gref}{an integer indicating which level of \code{g} to use as the reference
 group. Defaults to \code{1}.}
 
-\item{unwgt.var}{Defaults to \code{TRUE}}
+\item{unwgt.var}{Use unweighted or weighted covariance matrix. Defaults to \code{TRUE}}
 }
 \value{
 a \code{data.frame} containing standardized mean differences between
@@ -86,6 +86,14 @@ the sample variance.
 
 For a \code{logical} or \code{factor} with only two levels, the equation above is
 \eqn{\bar{x}_g = \hat{p}_g}, i.e. the sample proportion and \eqn{s^2_g = \hat{p}_g(1 - \hat{p}_g)}.
+
+When using the SMD to evaluate the effectiveness of weighting in achieving covariate balance,
+it is important to isolate the change in SMD before and after weighting to the change in mean
+difference, so the denominator (covariance matrix) must be held constant. By default, the 
+unweighted covariance matrix is used to compute SMD in both the unweighted and weighted case. 
+If the weights are not being used to adjust for covariate imbalance (e.g. case weights), 
+the \code{unwgt.var} argument can be set to \code{FALSE} to use the weighted covariance matrix 
+as the denominator.
 }
 \examples{
 x <- rnorm(100)

--- a/tests/testthat/test_smd.R
+++ b/tests/testthat/test_smd.R
@@ -24,22 +24,27 @@ test_that("smd() returns correct values in specific cases", {
   w <- rep(0:1, each = 5)
   # means in both groups are 0; some weights are 0;
   expect_equal(smd(x, g, w)$estimate, 0)
+  expect_equal(smd(x, g, w, unwgt.var = FALSE)$estimate, 0)
 
   # means in one group is not 0; some weights are 0;
   x <- rep(0:1, times = c(7, 3))
   gBx <- c(0, 0, 1, 1, 1)
   expect_equal(smd(x, g, w)$estimate, -0.6/sqrt((var(gBx) * 4 /5)/ 2))
+  expect_equal(smd(x, g, w, unwgt.var = FALSE)$estimate, -0.6/sqrt((var(gBx) * 4 /5)/ 2))
 
   # means in one group is not 0; some weights are 0;
   x <- rep(0:1, times = c(7, 3))
   w <- rep(0:1, times = c(6, 4))
   gBx <- c(0, 0, 1, 1, 1)
+  expect_equal(smd(x, g, w)$estimate,  -0.75/sqrt((var(gBx) * 4 /5)/ 2) )
   expect_equal(smd(x, g, w, unwgt.var = FALSE)$estimate, -0.75/sqrt( (sum(w[6:10]*(gBx - 0.75)^2)/4)/2) )
+
 
   # means in one group is not 0; some weights are 0;
   x <- rep(0:1, times = c(7, 3))
   w <- c(rep(0:1, times = c(6, 3)), 0)
   gBx <- c(0, 0, 1, 1, 1)
+  expect_equal(smd(x, g, w)$estimate,  -(2/3)/sqrt((var(gBx) * 4 /5)/ 2) )
   expect_equal(smd(x, g, w, unwgt.var = FALSE)$estimate, -(2/3)/sqrt( (sum(w[6:10]*(gBx - (2/3))^2)/3)/2) )
 
   # means in both group is not 0; some weights are 0;
@@ -47,19 +52,26 @@ test_that("smd() returns correct values in specific cases", {
   w <- rep(c(0, 1, 1, 1, 0), times = 2)
 
   expect_equal(smd(x, g, w)$estimate, 0)
+  expect_equal(smd(x, g, w, unwgt.var = FALSE)$estimate, 0)
 
   ## Checking factors
   x <- factor(rep(LETTERS[1:4], times = 4))
   g <- rep(c("a", "b"), each = 8)
   w <- c(rep(0:1, times = 4), rep(0:1, each = 4))
-
+  
   ra <- c(0, .5, 0, .5)
+  ra_unw <- c(0.25, 0.25, 0.25, 0.25)
   SSa <- diag(ra) - outer(ra, ra)
+  SSa_unw <- diag(ra_unw) - outer(ra_unw, ra_unw)
   rb <- c(.25, .25, .25, 0.25)
+  rb_unw <- c(.25, .25, .25, 0.25)
   SSb <- diag(rb) - outer(rb, rb)
+  SSb_unw <- diag(rb_unw) - outer(rb_unw, rb_unw)
   d <- ra - rb
   SS <- (SSa + SSb)/2
-
+  SS_unw <- (SSa_unw + SSb_unw)/2
+  
+  expect_equal(sqrt(t(d) %*% (MASS::ginv(SS_unw) %*% d)), smd(x, g, w)$estimate, check.attributes = FALSE)
   expect_equal(sqrt(t(d) %*% (MASS::ginv(SS) %*% d)), smd(x, g, w, unwgt.var = FALSE)$estimate, check.attributes = FALSE)
 
   w <- rep(0:1, each = 8)
@@ -71,7 +83,7 @@ test_that("smd() returns correct values in specific cases", {
   SS <- (SSa + SSb)/2
 
   expect_equal(sqrt(t(d) %*% (MASS::ginv(SS) %*% d)), smd(x, g, w)$estimate, check.attributes = FALSE)
-
+  expect_equal(sqrt(t(d) %*% (MASS::ginv(SS) %*% d)), smd(x, g, w, unwgt.var = FALSE)$estimate, check.attributes = FALSE)
 })
 
 

--- a/tests/testthat/test_smd.R
+++ b/tests/testthat/test_smd.R
@@ -34,13 +34,13 @@ test_that("smd() returns correct values in specific cases", {
   x <- rep(0:1, times = c(7, 3))
   w <- rep(0:1, times = c(6, 4))
   gBx <- c(0, 0, 1, 1, 1)
-  expect_equal(smd(x, g, w)$estimate, -0.75/sqrt( (sum(w[6:10]*(gBx - 0.75)^2)/4)/2) )
+  expect_equal(smd(x, g, w, unwgt.var = FALSE)$estimate, -0.75/sqrt( (sum(w[6:10]*(gBx - 0.75)^2)/4)/2) )
 
   # means in one group is not 0; some weights are 0;
   x <- rep(0:1, times = c(7, 3))
   w <- c(rep(0:1, times = c(6, 3)), 0)
   gBx <- c(0, 0, 1, 1, 1)
-  expect_equal(smd(x, g, w)$estimate, -(2/3)/sqrt( (sum(w[6:10]*(gBx - (2/3))^2)/3)/2) )
+  expect_equal(smd(x, g, w, unwgt.var = FALSE)$estimate, -(2/3)/sqrt( (sum(w[6:10]*(gBx - (2/3))^2)/3)/2) )
 
   # means in both group is not 0; some weights are 0;
   x <- rep(c(0, 1, 1, 1, 1), times = 2)
@@ -60,7 +60,7 @@ test_that("smd() returns correct values in specific cases", {
   d <- ra - rb
   SS <- (SSa + SSb)/2
 
-  expect_equal(sqrt(t(d) %*% (MASS::ginv(SS) %*% d)), smd(x, g, w)$estimate, check.attributes = FALSE)
+  expect_equal(sqrt(t(d) %*% (MASS::ginv(SS) %*% d)), smd(x, g, w, unwgt.var = FALSE)$estimate, check.attributes = FALSE)
 
   w <- rep(0:1, each = 8)
   ra <- c(0, 0, 0, 0)


### PR DESCRIPTION
@bsaul, I've been thinking more about SMDs and came across [this note](https://ngreifer.github.io/cobalt/articles/cobalt.html#variance-in-standardized-mean-differences-and-correlations) in the documentation for Noah Greifer's `cobalt` package, citing a couple papers by Elizabeth Stuart:

> A key detail is that the standard deviation, no matter how it is computed, is always computed using the unadjusted sample. This is line with how MatchIt computes standardized mean differences, and is recommended by Stuart ([2008](https://ngreifer.github.io/cobalt/articles/cobalt.html#ref-stuartDevelopingPracticalRecommendations2008), [2010](https://ngreifer.github.io/cobalt/articles/cobalt.html#ref-stuartMatchingMethodsCausal2010)). One reason to favor the use of the standard deviation of the unadjusted sample is that it prevents the [paradoxical situation](https://stats.stackexchange.com/a/565705/116195) that occurs when adjustment decreases both the mean difference and the spread of the sample, yielding a larger standardized mean difference than that prior to adjustment, even though the adjusted groups are now more similar. By using the same standard deviation before and after adjusting, the change in balance is isolated to the change in mean difference, rather than being conflated with an accompanying change in spread.

I've made minor tweaks so that the unadjusted variance is used as the denominator in `n_mean_var`. This would be a breaking change, though how often and how much the results would change is unclear to me. I suppose this could also be an argument, whether the user wants the unadjusted or adjusted variance as the denominator. Let me know what you think
